### PR TITLE
Update numbers in new user spec to satisfy Twilio requirements

### DIFF
--- a/spec/features/users/user_can_create_an_account_spec.rb
+++ b/spec/features/users/user_can_create_an_account_spec.rb
@@ -8,12 +8,12 @@ describe 'When a user visits `/users/new`' do
       fill_in 'user[email]', with: 'user@user.com'
       fill_in 'user[password]', with: 'password'
       fill_in 'user[password_confirmation]', with: 'password'
-      fill_in 'user[phone]', with: '555-555-5555'
+      fill_in 'user[phone]', with: '500-400-3000'
       click_on 'Subscribe'
 
       expect(page).to have_content('Successfully subscribed!')
       expect(page).to have_content('user@user.com')
-      expect(page).to have_content('555-555-5555')
+      expect(page).to have_content('500-400-3000')
       expect(User.count).to eq(1)
     end
   end
@@ -25,7 +25,7 @@ describe 'When a user visits `/users/new`' do
       fill_in 'user[email]', with: 'user@user.com'
       fill_in 'user[password]', with: 'password'
       fill_in 'user[password_confirmation]', with: 'pass'
-      fill_in 'user[phone]', with: '555-555-5555'
+      fill_in 'user[phone]', with: '500-400-3000'
       click_on 'Subscribe'
 
       expect(current_path).to eq('/users')
@@ -40,7 +40,7 @@ describe 'When a user visits `/users/new`' do
 
       fill_in 'user[password]', with: 'password'
       fill_in 'user[password_confirmation]', with: 'password'
-      fill_in 'user[phone]', with: '555-555-5555'
+      fill_in 'user[phone]', with: '500-400-3000'
       click_on 'Subscribe'
 
       expect(current_path).to eq('/users')


### PR DESCRIPTION
@case-eee Looks like Twilio doesn't like 555-555-5555 as a phone number. This spec passes with the number change.